### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
  ![](./pic/CanDialog.gif) 
  
  
-##添加依赖
+## 添加依赖
 ```JAVA
 compile 'com.canyinghao:candialog:1.0.6'
 ```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
